### PR TITLE
FastAPI の初期構築

### DIFF
--- a/application/README.md
+++ b/application/README.md
@@ -1,6 +1,18 @@
 # アプリケーション
 
-## ローカル開発用コンテナ環境
+## ローカルデモ用コンテナ環境
+
+### 構築コンテナ
+
+- frontend
+  - TBD
+- api
+  - `api/` ディレクトリに実装したイメージをコンテナ化して起動
+- dynamodb-demo
+  - デモ用の DynamoDB クローン
+  - 開発環境の DynamoDB と永続データを共有している
+- dynamodb-admin-demo
+  - GUI の DynamoDB 管理ツール
 
 ### 前提
 

--- a/application/api/Dockerfile
+++ b/application/api/Dockerfile
@@ -1,1 +1,10 @@
-FROM amazon/aws-cli:latest
+FROM python:3.9-slim
+
+COPY Pipfile .
+COPY Pipfile.lock .
+
+RUN pip install pipenv --no-cache-dir
+RUN pipenv sync --system  
+
+COPY main.py .
+CMD pipenv run server

--- a/application/api/Pipfile
+++ b/application/api/Pipfile
@@ -11,5 +11,9 @@ uvicorn = "*"
 autopep8 = "*"
 flake8 = "*"
 
+[scripts]
+server = "uvicorn main:app --port=8080 --host=0.0.0.0"
+local_server = "uvicorn main:app --reload --port=8080 --host=0.0.0.0"
+
 [requires]
 python_version = "3.9"

--- a/application/api/Pipfile
+++ b/application/api/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 fastapi = "*"
 uvicorn = "*"
+pynamodb = "*"
 
 [dev-packages]
 autopep8 = "*"

--- a/application/api/Pipfile
+++ b/application/api/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+fastapi = "*"
+uvicorn = "*"
+
+[dev-packages]
+autopep8 = "*"
+flake8 = "*"
+
+[requires]
+python_version = "3.9"

--- a/application/api/Pipfile.lock
+++ b/application/api/Pipfile.lock
@@ -1,0 +1,182 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "abf26ecaafd2235561cbee8b366acd5e9dbfad12fc8bd4f053c713541e40bfa2"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.9"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "anyio": {
+            "hashes": [
+                "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b",
+                "sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be"
+            ],
+            "markers": "python_full_version >= '3.6.2'",
+            "version": "==3.6.1"
+        },
+        "click": {
+            "hashes": [
+                "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
+                "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==8.1.3"
+        },
+        "fastapi": {
+            "hashes": [
+                "sha256:cf0ff6db25b91d321050c4112baab0908c90f19b40bf257f9591d2f9780d1f22",
+                "sha256:d337563424ceada23857f73d5abe8dae0c28e4cccb53b2af06e78b7bb4a1c7d7"
+            ],
+            "index": "pypi",
+            "version": "==0.79.0"
+        },
+        "h11": {
+            "hashes": [
+                "sha256:70813c1135087a248a4d38cc0e1a0181ffab2188141a93eaf567940c3957ff06",
+                "sha256:8ddd78563b633ca55346c8cd41ec0af27d3c79931828beffb46ce70a379e7442"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.13.0"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "pydantic": {
+            "hashes": [
+                "sha256:02eefd7087268b711a3ff4db528e9916ac9aa18616da7bca69c1871d0b7a091f",
+                "sha256:059b6c1795170809103a1538255883e1983e5b831faea6558ef873d4955b4a74",
+                "sha256:0bf07cab5b279859c253d26a9194a8906e6f4a210063b84b433cf90a569de0c1",
+                "sha256:1542636a39c4892c4f4fa6270696902acb186a9aaeac6f6cf92ce6ae2e88564b",
+                "sha256:177071dfc0df6248fd22b43036f936cfe2508077a72af0933d0c1fa269b18537",
+                "sha256:18f3e912f9ad1bdec27fb06b8198a2ccc32f201e24174cec1b3424dda605a310",
+                "sha256:1dd8fecbad028cd89d04a46688d2fcc14423e8a196d5b0a5c65105664901f810",
+                "sha256:1ed987c3ff29fff7fd8c3ea3a3ea877ad310aae2ef9889a119e22d3f2db0691a",
+                "sha256:447d5521575f18e18240906beadc58551e97ec98142266e521c34968c76c8761",
+                "sha256:494f7c8537f0c02b740c229af4cb47c0d39840b829ecdcfc93d91dcbb0779892",
+                "sha256:4988c0f13c42bfa9ddd2fe2f569c9d54646ce84adc5de84228cfe83396f3bd58",
+                "sha256:4ce9ae9e91f46c344bec3b03d6ee9612802682c1551aaf627ad24045ce090761",
+                "sha256:5d93d4e95eacd313d2c765ebe40d49ca9dd2ed90e5b37d0d421c597af830c195",
+                "sha256:61b6760b08b7c395975d893e0b814a11cf011ebb24f7d869e7118f5a339a82e1",
+                "sha256:72ccb318bf0c9ab97fc04c10c37683d9eea952ed526707fabf9ac5ae59b701fd",
+                "sha256:79b485767c13788ee314669008d01f9ef3bc05db9ea3298f6a50d3ef596a154b",
+                "sha256:7eb57ba90929bac0b6cc2af2373893d80ac559adda6933e562dcfb375029acee",
+                "sha256:8bc541a405423ce0e51c19f637050acdbdf8feca34150e0d17f675e72d119580",
+                "sha256:969dd06110cb780da01336b281f53e2e7eb3a482831df441fb65dd30403f4608",
+                "sha256:985ceb5d0a86fcaa61e45781e567a59baa0da292d5ed2e490d612d0de5796918",
+                "sha256:9bcf8b6e011be08fb729d110f3e22e654a50f8a826b0575c7196616780683380",
+                "sha256:9ce157d979f742a915b75f792dbd6aa63b8eccaf46a1005ba03aa8a986bde34a",
+                "sha256:9f659a5ee95c8baa2436d392267988fd0f43eb774e5eb8739252e5a7e9cf07e0",
+                "sha256:a4a88dcd6ff8fd47c18b3a3709a89adb39a6373f4482e04c1b765045c7e282fd",
+                "sha256:a955260d47f03df08acf45689bd163ed9df82c0e0124beb4251b1290fa7ae728",
+                "sha256:a9af62e9b5b9bc67b2a195ebc2c2662fdf498a822d62f902bf27cccb52dbbf49",
+                "sha256:ae72f8098acb368d877b210ebe02ba12585e77bd0db78ac04a1ee9b9f5dd2166",
+                "sha256:b83ba3825bc91dfa989d4eed76865e71aea3a6ca1388b59fc801ee04c4d8d0d6",
+                "sha256:c11951b404e08b01b151222a1cb1a9f0a860a8153ce8334149ab9199cd198131",
+                "sha256:c320c64dd876e45254bdd350f0179da737463eea41c43bacbee9d8c9d1021f11",
+                "sha256:c8098a724c2784bf03e8070993f6d46aa2eeca031f8d8a048dff277703e6e193",
+                "sha256:d12f96b5b64bec3f43c8e82b4aab7599d0157f11c798c9f9c528a72b9e0b339a",
+                "sha256:e565a785233c2d03724c4dc55464559639b1ba9ecf091288dd47ad9c629433bd",
+                "sha256:f0f047e11febe5c3198ed346b507e1d010330d56ad615a7e0a89fae604065a0e",
+                "sha256:fe4670cb32ea98ffbf5a1262f14c3e102cccd92b1869df3bb09538158ba90fe6"
+            ],
+            "markers": "python_full_version >= '3.6.1'",
+            "version": "==1.9.1"
+        },
+        "sniffio": {
+            "hashes": [
+                "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663",
+                "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.2.0"
+        },
+        "starlette": {
+            "hashes": [
+                "sha256:5a60c5c2d051f3a8eb546136aa0c9399773a689595e099e0877704d5888279bf",
+                "sha256:c6d21096774ecb9639acad41b86b7706e52ba3bf1dc13ea4ed9ad593d47e24c7"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==0.19.1"
+        },
+        "typing-extensions": {
+            "hashes": [
+                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
+                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+            ],
+            "markers": "python_version < '3.10'",
+            "version": "==4.3.0"
+        },
+        "uvicorn": {
+            "hashes": [
+                "sha256:c19a057deb1c5bb060946e2e5c262fc01590c6529c0af2c3d9ce941e89bc30e0",
+                "sha256:cade07c403c397f9fe275492a48c1b869efd175d5d8a692df649e6e7e2ed8f4e"
+            ],
+            "index": "pypi",
+            "version": "==0.18.2"
+        }
+    },
+    "develop": {
+        "autopep8": {
+            "hashes": [
+                "sha256:44f0932855039d2c15c4510d6df665e4730f2b8582704fa48f9c55bd3e17d979",
+                "sha256:ed77137193bbac52d029a52c59bec1b0629b5a186c495f1eb21b126ac466083f"
+            ],
+            "index": "pypi",
+            "version": "==1.6.0"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:479b1304f72536a55948cb40a32dce8bb0ffe3501e26eaf292c7e60eb5e0428d",
+                "sha256:806e034dda44114815e23c16ef92f95c91e4c71100ff52813adf7132a6ad870d"
+            ],
+            "index": "pypi",
+            "version": "==4.0.1"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:720f8b39dde8b293825e7ff02c475f3077124006db4f440dcbc9a20b76548a20",
+                "sha256:eddd5847ef438ea1c7870ca7eb78a9d47ce0cdb4851a5523949f2601d0cbbe7f"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==2.8.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:05a85c2872edf37a4ed30b0cce2f6093e1d0581f8c19d7393122da7e25b2b24c",
+                "sha256:3bb3a3f256f4b7968c9c788781e4ff07dce46bdf12339dcda61053375426ee2e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.4.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.2"
+        }
+    }
+}

--- a/application/api/Pipfile.lock
+++ b/application/api/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "abf26ecaafd2235561cbee8b366acd5e9dbfad12fc8bd4f053c713541e40bfa2"
+            "sha256": "67a7d2139d06deb8628700175a58193d74d882d0f0fa44faccb42e954050cdd1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -23,6 +23,14 @@
             ],
             "markers": "python_full_version >= '3.6.2'",
             "version": "==3.6.1"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:4dc9ac87a0981b60a02d1ea7c4d02bbccd0a79da4731905efcdc90c230182e57",
+                "sha256:bfbeebf2fb9832f9e79635e3320265be94f512de396d3d407ca3538f994ad2c8"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.27.33"
         },
         "click": {
             "hashes": [
@@ -55,6 +63,14 @@
             ],
             "markers": "python_version >= '3.5'",
             "version": "==3.3"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
         },
         "pydantic": {
             "hashes": [
@@ -97,6 +113,30 @@
             "markers": "python_full_version >= '3.6.1'",
             "version": "==1.9.1"
         },
+        "pynamodb": {
+            "hashes": [
+                "sha256:bb93bd86061c91508c44668c219d51d080d011f665153fa9a471ced06b2f2ee7",
+                "sha256:c7a9c557b52364bc09257edd00378eebc75258bbdaa0fe050fcce2356149f90a"
+            ],
+            "index": "pypi",
+            "version": "==5.2.1"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.8.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
         "sniffio": {
             "hashes": [
                 "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663",
@@ -120,6 +160,14 @@
             ],
             "markers": "python_version < '3.10'",
             "version": "==4.3.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec",
+                "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
+            "version": "==1.26.10"
         },
         "uvicorn": {
             "hashes": [

--- a/application/api/README.md
+++ b/application/api/README.md
@@ -1,0 +1,32 @@
+# API
+
+## 前提
+
+- [Docker](https://docs.docker.com/get-docker/)
+- [pipenv](https://pipenv-ja.readthedocs.io/ja/translate-ja/)
+- [FastAPI](https://fastapi.tiangolo.com/ja/)
+
+## FastAPI サーバの起動
+
+pipenv スクリプトを用意してある。
+
+```sh
+# 通常起動
+pipenv run server
+
+# 開発用の起動 (reload オプションが ON)
+pipenv run local_server
+```
+
+## ローカル開発用コンテナ環境
+
+デモ用コンテナとは別に、ローカル開発用に以下のコンテナが起動するようになっている。
+
+- DynamoDB
+  - ※データはデモ環境と共有している
+- dynamodb-admin
+
+### 利用方法
+
+基本的な動かし方は [デモ環境の手順](../README.md) と同じである。  
+開発中の FastAPI から疎通できるように設定して利用する。

--- a/application/api/docker-compose.yml
+++ b/application/api/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.7'
+services:
+  dynamodb-dev:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-dev
+    ports:
+      - "8011:8000"
+    volumes:
+      - dynamodb:/home/dynamodblocal
+    command: -jar DynamoDBLocal.jar -sharedDb -dbPath . -optimizeDbBeforeStartup
+    environment:
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: idol-cheki
+      AWS_SECRET_ACCESS_KEY: idol-cheki
+ 
+  dynamodb-admin-dev:
+    image: aaronshaf/dynamodb-admin:latest
+    container_name: dynamodb-admin-dev
+    ports:
+      - "8013:8001"
+    environment:
+      DYNAMO_ENDPOINT: dynamodb-dev:8000
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: idol-cheki
+      AWS_SECRET_ACCESS_KEY: idol-cheki
+    depends_on:
+      - dynamodb-dev
+
+volumes:
+  dynamodb:
+    driver: local

--- a/application/api/entrypoint.sh
+++ b/application/api/entrypoint.sh
@@ -1,8 +1,0 @@
-#!/bin/sh
-
-export AWS_ACCESS_KEY_ID=idol-cheki
-export AWS_SECRET_ACCESS_KEY=idol-cheki
-export AWS_DEFAULT_REGION=ap-northeast-1
-export AWS_DEFAULT_OUTPUT=json
-
-aws dynamodb list-tables --endpoint-url http://dynamodb-dev:8000 --no-cli-pager

--- a/application/api/main.py
+++ b/application/api/main.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+import dataclasses
+import uuid
+
+
+class IdolGroupInput(BaseModel):
+    name: str
+
+
+@dataclasses.dataclass
+class IdolGroup:
+    id: str
+    name: str
+
+
+data = dict()
+
+app = FastAPI()
+
+
+@app.post("/idol-groups/")
+async def create_idol_group(idol_group_input: IdolGroupInput) -> IdolGroup:
+    idol_group_id = str(uuid.uuid4())
+    idol_group = IdolGroup(idol_group_id, idol_group_input.name)
+    global data
+    data[idol_group_id] = idol_group
+    print(idol_group_id)
+    return idol_group
+
+
+@app.get("/idol-groups/")
+async def read_idol_groups() -> dict[IdolGroup]:
+    return data
+
+
+@app.get("/idol-groups/{idol_group_id}")
+async def read_idol_group(idol_group_id: str) -> IdolGroup:
+    return data[idol_group_id]
+
+
+@app.delete("/idol-groups/{idol_group_id}")
+async def delete_idol_group(idol_group_id: str) -> None:
+    del data[idol_group_id]

--- a/application/api/main.py
+++ b/application/api/main.py
@@ -1,44 +1,64 @@
+from typing import Type
 from fastapi import FastAPI
 from pydantic import BaseModel
-import dataclasses
+from pynamodb.models import Model
+from pynamodb.attributes import UnicodeAttribute, NumberAttribute
+import os
 import uuid
+
+TABLE_NAME = os.environ.get("TABLE_NAME")
 
 
 class IdolGroupInput(BaseModel):
     name: str
 
 
-@dataclasses.dataclass
-class IdolGroup:
-    id: str
-    name: str
+class IdolGroup(Model):
+    class Meta:
+        host = f'http://{os.environ.get("DYNAMO_ENDPOINT", "localhost:8011")}'
+        aws_access_key_id = os.environ.get("AWS_ACCESS_KEY_ID", "idol-cheki")
+        aws_secret_access_key = os.environ.get(
+            "AWS_SECRET_ACCESS_KEY", "idol-cheki")
+        region = os.environ.get("AWS_DEFAULT_REGION", "ap-northeast-1")
+        table_name = os.environ.get("TABLE_NAME", "idol-groups")
+    id: str = UnicodeAttribute(hash_key=True)
+    name: str = UnicodeAttribute(null=True)
 
-
-data = dict()
 
 app = FastAPI()
+
+
+@app.on_event("startup")
+def startup_event():
+    if not IdolGroup.exists():
+        IdolGroup.create_table(read_capacity_units=1,
+                               write_capacity_units=1, wait=True)
 
 
 @app.post("/idol-groups/")
 async def create_idol_group(idol_group_input: IdolGroupInput) -> IdolGroup:
     idol_group_id = str(uuid.uuid4())
-    idol_group = IdolGroup(idol_group_id, idol_group_input.name)
-    global data
-    data[idol_group_id] = idol_group
-    print(idol_group_id)
+    idol_group = IdolGroup(hash_key=idol_group_id, name=idol_group_input.name)
+    idol_group.save()
+
     return idol_group
 
 
 @app.get("/idol-groups/")
-async def read_idol_groups() -> dict[IdolGroup]:
-    return data
+async def list_idol_group() -> dict[IdolGroup]:
+    idol_groups = list()
+    for i in IdolGroup.scan():
+        idol_groups.append(i.attribute_values)
+    return idol_groups
 
 
 @app.get("/idol-groups/{idol_group_id}")
 async def read_idol_group(idol_group_id: str) -> IdolGroup:
-    return data[idol_group_id]
+    idol_group = IdolGroup.get(hash_key=idol_group_id)
+    return idol_group.attribute_values
 
 
 @app.delete("/idol-groups/{idol_group_id}")
 async def delete_idol_group(idol_group_id: str) -> None:
-    del data[idol_group_id]
+    target_idol_group = IdolGroup.get(idol_group_id)
+    target_idol_group.delete()

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -6,38 +6,10 @@ services:
     ports:
       - "8080:8080"
     environment:
-      AWS_REGION: ap-northeast-1
-      AWS_ACCESS_KEY_ID: idol-cheki
-      AWS_SECRET_ACCESS_KEY: idol-cheki
-    depends_on:
-      - dynamodb-dev
-
-  dynamodb-dev:
-    image: amazon/dynamodb-local:latest
-    container_name: dynamodb-dev
-    ports:
-      - "8011:8000"
-    volumes:
-      - dynamodb:/home/dynamodblocal
-    command: -jar DynamoDBLocal.jar -sharedDb -dbPath . -optimizeDbBeforeStartup
-    environment:
-      AWS_REGION: ap-northeast-1
-      AWS_ACCESS_KEY_ID: idol-cheki
-      AWS_SECRET_ACCESS_KEY: idol-cheki
- 
-  dynamodb-admin-dev:
-    image: aaronshaf/dynamodb-admin:latest
-    container_name: dynamodb-admin-dev
-    ports:
-      - "8013:8001"
-    environment:
       DYNAMO_ENDPOINT: dynamodb-dev:8000
-      AWS_REGION: ap-northeast-1
       AWS_ACCESS_KEY_ID: idol-cheki
       AWS_SECRET_ACCESS_KEY: idol-cheki
+      AWS_DEFAULT_REGION: ap-northeast-1
+      TABLE_NAME: idol-groups
     depends_on:
       - dynamodb-dev
-
-volumes:
-  dynamodb:
-    driver: local

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -4,14 +4,11 @@ services:
     container_name: api
     build: ./api/
     ports:
-      - "8080:80"
-    volumes:
-      - ./api/entrypoint.sh:/tmp/entrypoint.sh
+      - "8080:8080"
     environment:
       AWS_REGION: ap-northeast-1
       AWS_ACCESS_KEY_ID: idol-cheki
       AWS_SECRET_ACCESS_KEY: idol-cheki
-    entrypoint: /tmp/entrypoint.sh
     depends_on:
       - dynamodb-dev
 

--- a/application/docker-compose.yml
+++ b/application/docker-compose.yml
@@ -6,10 +6,40 @@ services:
     ports:
       - "8080:8080"
     environment:
-      DYNAMO_ENDPOINT: dynamodb-dev:8000
+      DYNAMO_ENDPOINT: dynamodb-demo:8000
       AWS_ACCESS_KEY_ID: idol-cheki
       AWS_SECRET_ACCESS_KEY: idol-cheki
       AWS_DEFAULT_REGION: ap-northeast-1
       TABLE_NAME: idol-groups
     depends_on:
-      - dynamodb-dev
+      - dynamodb-demo
+
+  dynamodb-demo:
+    image: amazon/dynamodb-local:latest
+    container_name: dynamodb-demo
+    ports:
+      - "8011:8000"
+    volumes:
+      - dynamodb:/home/dynamodblocal
+    command: -jar DynamoDBLocal.jar -sharedDb -dbPath . -optimizeDbBeforeStartup
+    environment:
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: idol-cheki
+      AWS_SECRET_ACCESS_KEY: idol-cheki
+ 
+  dynamodb-admin-demo:
+    image: aaronshaf/dynamodb-admin:latest
+    container_name: dynamodb-admin-demo
+    ports:
+      - "8013:8001"
+    environment:
+      DYNAMO_ENDPOINT: dynamodb-demo:8000
+      AWS_REGION: ap-northeast-1
+      AWS_ACCESS_KEY_ID: idol-cheki
+      AWS_SECRET_ACCESS_KEY: idol-cheki
+    depends_on:
+      - dynamodb-demo
+
+volumes:
+  dynamodb:
+    driver: local


### PR DESCRIPTION
ふいんきで FastAPI から DynamoDB に疎通する単純な API サーバを初期構築。あんまり丁寧ではない。

`application/` ディレクトリに構築したデモ用コンテナ環境はあくまでデモで、これを起動しながら開発するには不便。  
`application/api/` ディレクトリに FastAPI 本体と開発用コンテナ環境を構築してあるので、こちらを動かしながら開発する想定。  
ただし双方とも DynamoDB の永続データは共有しているので、そこは使いまわせる。